### PR TITLE
Update Terraform terraform-aws-modules/notify-slack/aws to 4.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ No provider.
 | Name | Source | Version |
 |------|--------|---------|
 | default_label | cloudposse/label/null | 0.22.1 |
-| notify_slack | terraform-aws-modules/notify-slack/aws | 4.12 |
+| notify_slack | terraform-aws-modules/notify-slack/aws | 4.17 |
 | this | cloudposse/label/null | 0.24.1 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,7 +19,7 @@ No provider.
 | Name | Source | Version |
 |------|--------|---------|
 | default_label | cloudposse/label/null | 0.22.1 |
-| notify_slack | terraform-aws-modules/notify-slack/aws | 4.12 |
+| notify_slack | terraform-aws-modules/notify-slack/aws | 4.17 |
 | this | cloudposse/label/null | 0.24.1 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "default_label" {
 
 module "notify_slack" {
   source               = "terraform-aws-modules/notify-slack/aws"
-  version              = "4.12"
+  version              = "4.17"
   create               = module.this.enabled
   create_sns_topic     = var.create_sns_topic
   lambda_function_name = module.default_label.id


### PR DESCRIPTION
## what
* Module terraform-aws-modules/notify-slack/aws updated to latest version 4.17

## why
* Fixes error on newer Terfaform versions: #24
```
│ Error: Error in function call
│ 
│   on .terraform/modules/notify_slack_east.notify_slack/main.tf line 28, in locals:
│   28:     resources = [replace("${element(concat(aws_cloudwatch_log_group.lambda[*].arn, list("")), 0)}:*", ":*:*", ":*")]
│ 
│ Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list.
```

## references
* Closes #24

