### PR TITLE
Added the VPC params to the call of the notify_slack module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,15 +6,17 @@ module "default_label" {
 }
 
 module "notify_slack" {
-  source               = "terraform-aws-modules/notify-slack/aws"
-  version              = "5.5"
-  create               = module.this.enabled
-  create_sns_topic     = var.create_sns_topic
-  lambda_function_name = module.default_label.id
-  slack_webhook_url    = var.slack_webhook_url
-  slack_channel        = var.slack_channel
-  slack_username       = var.slack_username
-  slack_emoji          = var.slack_emoji
-  kms_key_arn          = var.kms_key_arn
-  sns_topic_name       = var.sns_topic_name
+  source                                 = "terraform-aws-modules/notify-slack/aws"
+  version                                = "5.5"
+  create                                 = module.this.enabled
+  create_sns_topic                       = var.create_sns_topic
+  lambda_function_name                   = module.default_label.id
+  slack_webhook_url                      = var.slack_webhook_url
+  slack_channel                          = var.slack_channel
+  slack_username                         = var.slack_username
+  slack_emoji                            = var.slack_emoji
+  kms_key_arn                            = var.kms_key_arn
+  sns_topic_name                         = var.sns_topic_name
+  lambda_function_vpc_subnet_ids         = var.vpc_subnet_ids
+  lambda_function_vpc_security_group_ids = var.vpc_security_group_ids
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,15 @@ variable "sns_topic_name" {
   description = "Name of the SNS topic to subscribe to."
   default     = ""
 }
+
+variable "vpc_subnet_ids" {
+  description = "List of subnet ids when the notifying Lambda Function should run in the VPC. Usually private or intra subnets."
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of security group ids when the notifying Lambda Function should run in the VPC."
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
## what

- Added VPC params to be able to deploy the Lambda inside VPC as well

## why

- PCI DSS requires any Lambda to be deployed inside a VPC

## references

- https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-pci-dss.html
