### PR TITLE
Add tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,4 +20,5 @@ module "notify_slack" {
   lambda_function_vpc_subnet_ids         = var.vpc_subnet_ids
   lambda_function_vpc_security_group_ids = var.vpc_security_group_ids
   lambda_source_path                     = var.lambda_source_path
+  tags                                   = module.this.tags
 }


### PR DESCRIPTION
## what

- Use `tags = module.this.tags` on the notify_slack resource.

## why

- Enhanced manageability: Tags enable better resource management, cost tracking, and security strategies.
- Consistency: Tagging the notify_slack resource provides consistency across all project resources.
- Discovery: Tags assist in faster resource locating when filtering or searching.


