### PR TITLE
fix: add an attribute to examples/completed to avoid name conflict in test concurrent runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ module "notify_slack" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >=1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_default_label"></a> [default\_label](#module\_default\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | terraform-aws-modules/notify-slack/aws | 5.6 |
+| <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | terraform-aws-modules/notify-slack/aws | 6.4.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >=1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,7 +19,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_default_label"></a> [default\_label](#module\_default\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | terraform-aws-modules/notify-slack/aws | 5.6 |
+| <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | terraform-aws-modules/notify-slack/aws | 6.4.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,4 +9,8 @@ module "notify_slack" {
   slack_webhook_url = var.slack_webhook_url
   slack_channel     = var.slack_channel
   slack_username    = var.slack_username
+  # Add MD5 hash of a timestamp attribute to avoid conflict for concurrent test runs, e.g.:
+  # `Error: creating CloudWatch Logs Log Group (/aws/lambda/eg-test-sns-default):
+  # ResourceAlreadyExistsException: The specified log group already exists.`
+  attributes = [md5(timestamp())]
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "default_label" {
 
 module "notify_slack" {
   source                                 = "terraform-aws-modules/notify-slack/aws"
-  version                                = "5.6"
+  version                                = "6.4.0"
   create                                 = module.this.enabled
   create_sns_topic                       = var.create_sns_topic
   lambda_function_name                   = module.default_label.id

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

- Adds an attribute to the `examples/competed` root module - the MD5 hash of a timestamp. Thit adds a "random" attribute to the resources and helps to avoid resource name conflict during the concurrent runs, [e.g.]:
  ```
  Error: creating CloudWatch Logs Log Group (/aws/lambda/eg-test-sns-default): operation error CloudWatch Logs: 
  CreateLogGroup, https response error StatusCode: 400, RequestID: 1eefd044-082e-4b8e-8c3b-0b3c3f2dd8a8, 
  ResourceAlreadyExistsException: The specified log group already exists
  ```
- Bumps `terraform-aws-modules/notify-slack/aws` to support newer Python version before 3.8 EOL 

## why

- [Tests are failing](https://github.com/cloudposse/actions/actions/runs/9781783844/job/27006652745).
- See the initial discussion in this thread https://github.com/cloudposse/terraform-aws-sns-lambda-notify-slack/pull/57#issuecomment-2160691447
