### PR TITLE
Fix: constant retriggers of lambda archive, bump notify-slack module 6.7.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "default_label" {
 
 module "notify_slack" {
   source                                 = "terraform-aws-modules/notify-slack/aws"
-  version                                = "6.4.0"
+  version                                = "6.7.0"
   create                                 = module.this.enabled
   create_sns_topic                       = var.create_sns_topic
   lambda_function_name                   = module.default_label.id


### PR DESCRIPTION
## what

Bump notify_slack module to latest

## why

Slack lambda archive continually triggers null resource because of timestamp causing terraform to say there's drift

## references

https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/232#issuecomment-2327599862
